### PR TITLE
Daily Step Count Goal & Notifications

### DIFF
--- a/StudyApplication/Engagements/DailyStepCountGoal/DailyStepCountGoal.swift
+++ b/StudyApplication/Engagements/DailyStepCountGoal/DailyStepCountGoal.swift
@@ -75,11 +75,9 @@ struct DailyStepCountGoal: View {
             action: {
                 guard dailyStepCountGoalModule.stepCountGoal > 3 * Constants.stepCountGoalIncrement else {
                     dailyStepCountGoalModule.stepCountGoal = 2 * Constants.stepCountGoalIncrement
-                    print("Decrease GUARD ...")
                     return
                 }
                 dailyStepCountGoalModule.stepCountGoal -= Constants.stepCountGoalIncrement
-                print("Decrease ...")
             },
             label: {
                 Image(systemName: "minus.circle")
@@ -95,7 +93,6 @@ struct DailyStepCountGoal: View {
         Button(
             action: {
                 dailyStepCountGoalModule.stepCountGoal += Constants.stepCountGoalIncrement
-                print("Increase ...")
             },
             label: {
                 Image(systemName: "plus.circle")

--- a/StudyApplication/Engagements/DailyStepCountGoal/DailyStepCountGoalModule.swift
+++ b/StudyApplication/Engagements/DailyStepCountGoal/DailyStepCountGoalModule.swift
@@ -133,7 +133,7 @@ class DailyStepCountGoalModule: Module, EnvironmentAccessible, DefaultInitializa
     
     private func updateStepCountNotification() async {
         // Remove all already delivered notifications
-        let oldNotifications = notifications.filter({ $0.key <= .now })
+        let oldNotifications = notifications.filter { $0.key <= .now }
         UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: oldNotifications.map(\.value))
         for oldNotification in oldNotifications {
             notifications[oldNotification.key] = nil

--- a/StudyApplication/Engagements/DailyStepCountGoal/DailyStepCountGoalModule.swift
+++ b/StudyApplication/Engagements/DailyStepCountGoal/DailyStepCountGoalModule.swift
@@ -11,6 +11,7 @@ import OSLog
 import Spezi
 import SpeziHealthKit
 import SpeziLocalStorage
+import UserNotifications
 
 
 @Observable
@@ -23,15 +24,57 @@ class DailyStepCountGoalModule: Module, EnvironmentAccessible, DefaultInitializa
     
     private var queryTask: Task<Void, Error>?
     private var dayChangedTask: Task<Void, Never>?
-    private(set) var todayStepCount: Int = 0
+    private(set) var todayStepCount: Int = 0 {
+        didSet {
+            Task {
+                await updateStepCountNotification()
+            }
+        }
+    }
     var stepCountGoal: Int = 10_000 {
         didSet {
             do {
                 try localStorage.store(stepCountGoal, storageKey: StorageKeys.dailyStepCountGoal)
+                
+                logger.debug("Step count goal changed to: \(self.stepCountGoal)")
+                
+                Task {
+                    await resetAllNotifications()
+                }
             } catch {
                 logger.error("Could not store enrolled studies.")
             }
         }
+    }
+    var notifications: [Date: String] = [:] {
+        didSet {
+            do {
+                try localStorage.store(notifications, storageKey: StorageKeys.dailyStepCountGoalNotifications)
+            } catch {
+                logger.error("Could not store step count goal notifications.")
+            }
+        }
+    }
+    
+    private var statisticsCollectionQueryDescriptor: HKStatisticsCollectionQueryDescriptor {
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: .now)
+        
+        guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
+            fatalError("Could not generate end of day for day: \(startOfDay). Will not execure query.")
+        }
+
+        let stepsToday = HKSamplePredicate.quantitySample(
+            type: HKQuantityType(.stepCount),
+            predicate: HKQuery.predicateForSamples(withStart: startOfDay, end: endOfDay)
+        )
+
+        return HKStatisticsCollectionQueryDescriptor(
+            predicate: stepsToday,
+            options: .cumulativeSum,
+            anchorDate: startOfDay,
+            intervalComponents: DateComponents(day: 1)
+        )
     }
     
     
@@ -46,10 +89,12 @@ class DailyStepCountGoalModule: Module, EnvironmentAccessible, DefaultInitializa
                 }
             } else {
                 #warning("We need to store the step count goal in Firebase and observe changes in the study app.")
+                // Important to store the notifications first before retrieving the step count goal as this is used to update notifications.
+                self.notifications = try localStorage.read(storageKey: StorageKeys.dailyStepCountGoalNotifications)
                 self.stepCountGoal = try localStorage.read(storageKey: StorageKeys.dailyStepCountGoal)
             }
         } catch {
-            logger.info("Could not retrieve existing step count goal.")
+            logger.info("Could not retrieve existing step count goal or notifications.")
         }
         
         // We use observation tracking to observe healthKit.authorized.
@@ -58,6 +103,90 @@ class DailyStepCountGoalModule: Module, EnvironmentAccessible, DefaultInitializa
             if authorized {
                 self.executeStatisticsQuery()
             }
+        }
+    }
+    
+    func refreshTodayStepCount() async {
+        logger.debug("Refresh today's step count.")
+        
+        guard let result = try? await statisticsCollectionQueryDescriptor.result(for: healthStore),
+              let todayStepCount = result.todayStepCount,
+              self.todayStepCount != todayStepCount else {
+            return
+        }
+        
+        self.todayStepCount = todayStepCount
+        logger.debug("Step count changed to: \(todayStepCount) (Refresh)")
+        
+        await updateStepCountNotification()
+    }
+    
+    private func resetAllNotifications() async {
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: notifications.map(\.value))
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: notifications.map(\.value))
+        notifications = [:]
+        
+        logger.debug("Reset all notification.")
+        
+        await updateStepCountNotification()
+    }
+    
+    private func updateStepCountNotification() async {
+        // Remove all already delivered notifications
+        let oldNotifications = notifications.filter({ $0.key <= .now })
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: oldNotifications.map(\.value))
+        for oldNotification in oldNotifications {
+            notifications[oldNotification.key] = nil
+            logger.debug("Removed old notification for \(oldNotification.key.formatted(date: .long, time: .omitted)).")
+        }
+        
+        // Schedule Notifications for the next 7 days if they do not already exist
+        let startOfDay = Calendar.current.startOfDay(for: .now)
+        
+        for daysFromNow in 0...7 {
+            guard let futureStartOfDay = Calendar.current.date(byAdding: .day, value: daysFromNow, to: startOfDay) else {
+                continue
+            }
+            
+            guard notifications[futureStartOfDay] == nil else {
+                continue
+            }
+            
+            // We schedule the notifications every day at 5 PM.
+            var dateComponents = Calendar.current.dateComponents([.day, .month, .year], from: futureStartOfDay)
+            dateComponents.hour = 17
+            dateComponents.minute = 0
+            
+            guard let notificationDate = Calendar.current.date(from: dateComponents), notificationDate > .now else {
+                continue
+            }
+            
+            let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+            
+            let content = UNMutableNotificationContent()
+            content.title = String(
+                localized: "Your Daily Step Goal"
+            )
+            content.body = String(
+                localized: "Reminder to meet your daily step goal of \(stepCountGoal) steps. Open the Spezi Study App to see your current steps for the day."
+            )
+            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+            do {
+                try await UNUserNotificationCenter.current().add(request)
+                logger.debug("Scheduled Notification for \(futureStartOfDay.formatted(date: .long, time: .omitted)) at 5 PM (Goal: \(self.stepCountGoal))")
+            } catch {
+                logger.warning("Could not schedule notification for \(futureStartOfDay.formatted(date: .long, time: .omitted)) at 5 PM (Goal: \(self.stepCountGoal)): \(error)")
+            }
+            
+            notifications[futureStartOfDay] = request.identifier
+        }
+        
+        
+        // Remove notification for today if we are above our step count goal
+        if let todaysNotification = notifications[startOfDay], todayStepCount >= stepCountGoal {
+            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [todaysNotification])
+            notifications[startOfDay] = nil
+            logger.debug("Removed today's step count goal notification as we have reached the step count goal.")
         }
     }
     
@@ -73,40 +202,20 @@ class DailyStepCountGoalModule: Module, EnvironmentAccessible, DefaultInitializa
         observeDayChanged()
         
         queryTask = Task {
-            let calendar = Calendar.current
-            let startOfDay = calendar.startOfDay(for: .now)
-            
-            guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
-                logger.debug("Could not generate end of day for day: \(startOfDay). Will not execure query.")
-                return
-            }
-
-            let stepsToday = HKSamplePredicate.quantitySample(
-                type: HKQuantityType(.stepCount),
-                predicate: HKQuery.predicateForSamples(withStart: startOfDay, end: endOfDay)
-            )
-
-            let stepsTodayQuery = HKStatisticsCollectionQueryDescriptor(
-                predicate: stepsToday,
-                options: .cumulativeSum,
-                anchorDate: startOfDay,
-                intervalComponents: DateComponents(day: 1)
-            )
-            
             do {
-                for try await results in stepsTodayQuery.results(for: healthStore) {
+                for try await results in statisticsCollectionQueryDescriptor.results(for: healthStore) {
                     guard !Task.isCancelled else {
                         logger.debug("Task was cancelled, exeting results loop.")
                         return
                     }
                     
-                    guard let result = results.statisticsCollection.statistics(for: startOfDay),
-                          let stepCount = result.sumQuantity()?.doubleValue(for: HKUnit.count()) else {
+                    guard let todayStepCount = results.statisticsCollection.todayStepCount else {
                         logger.warning("Could not retrieve expected result from startistics collection.")
                         continue
                     }
                     
-                    self.todayStepCount = Int(stepCount)
+                    self.todayStepCount = todayStepCount
+                    logger.debug("Step count changed to: \(todayStepCount)")
                 }
             } catch {
                 logger.error("Could not execure HealthKit query: \(error)")
@@ -131,5 +240,17 @@ class DailyStepCountGoalModule: Module, EnvironmentAccessible, DefaultInitializa
     deinit {
         dayChangedTask?.cancel()
         queryTask?.cancel()
+    }
+}
+
+
+extension HKStatisticsCollection {
+    fileprivate var todayStepCount: Int? {
+        guard let result = self.statistics(for: .now),
+              let stepCount = result.sumQuantity()?.doubleValue(for: HKUnit.count()) else {
+            return nil
+        }
+        
+        return Int(stepCount)
     }
 }

--- a/StudyApplication/Resources/Localizable.xcstrings
+++ b/StudyApplication/Resources/Localizable.xcstrings
@@ -240,6 +240,9 @@
     "Redeem Inviation Code" : {
 
     },
+    "Reminder to meet your daily step goal of %lld steps. Open the Spezi Study App to see your current steps for the day." : {
+
+    },
     "Repository Link" : {
       "localizations" : {
         "en" : {
@@ -319,6 +322,9 @@
 
     },
     "You will need to provide the application permission to get access to the data that the study collects." : {
+
+    },
+    "Your Daily Step Goal" : {
 
     },
     "Your First Steps" : {

--- a/StudyApplication/SharedContext/StorageKeys.swift
+++ b/StudyApplication/SharedContext/StorageKeys.swift
@@ -28,4 +28,6 @@ enum StorageKeys {
     // MARK: - Engagements
     /// Daily step count goal
     static let dailyStepCountGoal = "engagement.dailyStepCountGoal"
+    /// Daily step count goal
+    static let dailyStepCountGoalNotifications = "engagement.dailyStepCountGoal.notifications"
 }

--- a/StudyApplication/StudyApplicationStandard.swift
+++ b/StudyApplication/StudyApplicationStandard.swift
@@ -32,6 +32,7 @@ actor StudyApplicationStandard: Standard, EnvironmentAccessible, HealthKitConstr
     
     
     @Application(\.logger) private var logger: Logger
+    @Dependency private var dailyStepCountGoalModule: DailyStepCountGoalModule
     @Dependency private var studyModule: StudyModule
     
     
@@ -68,6 +69,10 @@ actor StudyApplicationStandard: Standard, EnvironmentAccessible, HealthKitConstr
 
 
     func add(sample: HKSample) async {
+        if sample.sampleType == HKQuantityType(.stepCount) {
+            await dailyStepCountGoalModule.refreshTodayStepCount()
+        }
+        
         guard !FeatureFlags.disableFirebase else {
             logger.debug("Firebase disabled - would upload HKSample: \(sample)")
             return


### PR DESCRIPTION
# Daily Step Count Goal & Notifications

## :gear: Release Notes 
- Schedules a notification at 5 PM to remind the user to reach their daily step count goal
- Updates the notification based on the currently achieved step counts and removes notification of the application already determines that the user has achieved their step count goal.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
